### PR TITLE
✨  Implemented dark mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,9 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:github_search/src/constants/my_theme.dart';
+import 'package:github_search/src/features/settings/presentation/theme/theme_mode_notifier.dart';
+import 'package:github_search/src/features/settings/presentation/theme/use_device_theme_mode_notifier.dart';
 import 'package:github_search/src/router/app_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -27,6 +30,13 @@ class MainApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final goRouter = ref.watch(goRouterProvider);
+    final themeMode = ref.watch(appThemeModeProvider).valueOrNull;
+    final useDeviceTheme = ref.watch(useDeviceThemeProvider).valueOrNull;
+
+    // 非同期の読み込みが完了したかどうかを確認
+    if (themeMode == null || useDeviceTheme == null) {
+      return const SizedBox.shrink(); // ローディング中の場合、空のウィジェットを返す
+    }
 
     // ロードが完了したらスプラッシュ画面を削除
     FlutterNativeSplash.remove();
@@ -42,6 +52,9 @@ class MainApp extends ConsumerWidget {
         Locale('en', ''), // English
         Locale('ja', ''), // 日本語
       ],
+      theme: lightTheme,
+      darkTheme: darkTheme,
+      themeMode: useDeviceTheme == true ? ThemeMode.system : themeMode,
       debugShowCheckedModeBanner: false,
       routerConfig: goRouter,
     );

--- a/lib/src/constants/app_sizes.dart
+++ b/lib/src/constants/app_sizes.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class Sizes {
+  static const p4 = 4.0;
+  static const p8 = 8.0;
+  static const p12 = 12.0;
+  static const p16 = 16.0;
+  static const p20 = 20.0;
+  static const p24 = 24.0;
+  static const p32 = 32.0;
+  static const p48 = 48.0;
+  static const p64 = 64.0;
+}
+
+/// Constant gap widths
+const gapW4 = SizedBox(width: Sizes.p4);
+const gapW8 = SizedBox(width: Sizes.p8);
+const gapW12 = SizedBox(width: Sizes.p12);
+const gapW16 = SizedBox(width: Sizes.p16);
+const gapW20 = SizedBox(width: Sizes.p20);
+const gapW24 = SizedBox(width: Sizes.p24);
+const gapW32 = SizedBox(width: Sizes.p32);
+const gapW48 = SizedBox(width: Sizes.p48);
+const gapW64 = SizedBox(width: Sizes.p64);
+
+/// Constant gap heights
+const gapH4 = SizedBox(height: Sizes.p4);
+const gapH8 = SizedBox(height: Sizes.p8);
+const gapH12 = SizedBox(height: Sizes.p12);
+const gapH16 = SizedBox(height: Sizes.p16);
+const gapH20 = SizedBox(height: Sizes.p20);
+const gapH24 = SizedBox(height: Sizes.p24);
+const gapH32 = SizedBox(height: Sizes.p32);
+const gapH48 = SizedBox(height: Sizes.p48);
+const gapH64 = SizedBox(height: Sizes.p64);

--- a/lib/src/constants/my_theme.dart
+++ b/lib/src/constants/my_theme.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+// ライトテーマ
+ThemeData lightTheme = ThemeData(
+  colorScheme: const ColorScheme.light(
+    // メインカラー
+    primary: Color(0xffd4eaf7),
+    onPrimary: Color(0xff3b3c3d),
+
+    // アクセント1
+    secondary: Color(0xff71c4ef),
+    onSecondary: Color(0xff3b3c3d),
+
+    // アクセント2
+    tertiary: Color(0xff00668c),
+    onTertiary: Color(0xff3b3c3d),
+
+    // エラー
+    error: Color.fromARGB(255, 161, 67, 67),
+    onError: Color.fromARGB(255, 211, 211, 211),
+
+    // 背景
+    surface: Color(0xfffffefb),
+    onSurface: Color(0xff1d1c1c),
+    surfaceContainer: Color(0xfff5f4f1),
+  ),
+);
+
+// ダークテーマ
+ThemeData darkTheme = ThemeData(
+  colorScheme: const ColorScheme.dark(
+    // メインカラー
+    primary: Color(0xff1F3A5F),
+    onPrimary: Color(0xffacc2ef),
+
+    // アクセント1
+    secondary: Color(0xff3D5A80),
+    onSecondary: Color(0xffacc2ef),
+
+    // アクセント2
+    tertiary: Color(0xffcee8ff),
+    onTertiary: Color(0xffacc2ef),
+
+    // エラー
+    error: Color.fromARGB(255, 161, 67, 67),
+    onError: Color.fromARGB(255, 211, 211, 211),
+
+    // 背景
+    surface: Color(0xff0f1c2e),
+    onSurface: Color(0xffe0e0e0),
+    surfaceContainer: Color(0xff1f2b3e),
+  ),
+);

--- a/lib/src/features/settings/presentation/general/settings_page.dart
+++ b/lib/src/features/settings/presentation/general/settings_page.dart
@@ -1,27 +1,89 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:github_search/src/router/app_router.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:settings_ui/settings_ui.dart';
 
 class SettingsPage extends HookConsumerWidget {
   const SettingsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // アプリのバージョンを取得
+    final fromPlatform = useMemoized(PackageInfo.fromPlatform);
+    final snapshot = useFuture(fromPlatform);
+    if (!snapshot.hasData) {
+      return const SizedBox.shrink();
+    }
+
     return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('Settings Page'),
-            ElevatedButton(
-              onPressed: () {
-                context.goNamed(AppRoute.language.name);
-              },
-              child: const Text('Go to Language Select'),
-            ),
-          ],
+      body: SettingsList(
+        darkTheme: SettingsThemeData(
+          settingsListBackground: Theme.of(context).colorScheme.surface,
+          settingsSectionBackground: Theme.of(context).colorScheme.surfaceContainer,
         ),
+        lightTheme: SettingsThemeData(
+          settingsListBackground: Theme.of(context).colorScheme.surface,
+          settingsSectionBackground: Theme.of(context).colorScheme.surfaceContainer,
+        ),
+        platform: DevicePlatform.iOS,
+        sections: [
+          // アプリの外観設定
+          SettingsSection(
+            title: Text(AppLocalizations.of(context)!.appAppearance),
+            tiles: [
+              // ダークモードの切り替え
+              SettingsTile.switchTile(
+                leading: const Icon(Icons.brightness_4),
+                title: Text(AppLocalizations.of(context)!.darkMode),
+                initialValue: false,
+                onToggle: (value) {},
+              ),
+
+              // 端末のテーマ設定を使うかどうか
+              SettingsTile.switchTile(
+                leading: const Icon(Icons.app_settings_alt_rounded),
+                title: Text(AppLocalizations.of(context)!.useDeviceTheme),
+                initialValue: false,
+                onToggle: (value) {},
+              ),
+
+              // 言語設定
+              SettingsTile(
+                leading: const Icon(Icons.language),
+                title: Text(AppLocalizations.of(context)!.language),
+                value: const Row(
+                  children: [
+                    Text(
+                      'English',
+                      style: TextStyle(
+                        fontSize: 15,
+                      ),
+                    ),
+                    Icon(color: Colors.grey, Icons.keyboard_arrow_right),
+                  ],
+                ),
+                onPressed: (context) => context.goNamed(AppRoute.language.name),
+              ),
+            ],
+          ),
+
+          // アプリについて
+          SettingsSection(
+            title: Text(AppLocalizations.of(context)!.aboutApp),
+            tiles: <SettingsTile>[
+              // バージョン情報
+              SettingsTile(
+                leading: const Icon(Icons.info),
+                title: Text(AppLocalizations.of(context)!.version),
+                value: Text("${snapshot.data?.version}"),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/settings/presentation/general/settings_page.dart
+++ b/lib/src/features/settings/presentation/general/settings_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:github_search/src/features/settings/presentation/theme/theme_mode_notifier.dart';
+import 'package:github_search/src/features/settings/presentation/theme/use_device_theme_mode_notifier.dart';
 import 'package:github_search/src/router/app_router.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -12,6 +14,12 @@ class SettingsPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // ダークモードのオンオフ
+    final isDarkMode = ref.watch(appThemeModeProvider).valueOrNull == ThemeMode.dark;
+
+    // 端末の設定を使うかどうか
+    final useDeviceTheme = ref.watch(useDeviceThemeProvider).valueOrNull ?? false;
+
     // アプリのバージョンを取得
     final fromPlatform = useMemoized(PackageInfo.fromPlatform);
     final snapshot = useFuture(fromPlatform);
@@ -39,16 +47,20 @@ class SettingsPage extends HookConsumerWidget {
               SettingsTile.switchTile(
                 leading: const Icon(Icons.brightness_4),
                 title: Text(AppLocalizations.of(context)!.darkMode),
-                initialValue: false,
-                onToggle: (value) {},
+                initialValue: isDarkMode,
+                onToggle: (value) {
+                  ref.read(appThemeModeProvider.notifier).toggleTheme();
+                },
               ),
 
               // 端末のテーマ設定を使うかどうか
               SettingsTile.switchTile(
                 leading: const Icon(Icons.app_settings_alt_rounded),
                 title: Text(AppLocalizations.of(context)!.useDeviceTheme),
-                initialValue: false,
-                onToggle: (value) {},
+                initialValue: useDeviceTheme,
+                onToggle: (value) {
+                  ref.read(useDeviceThemeProvider.notifier).toggleUseDeviceTheme();
+                },
               ),
 
               // 言語設定

--- a/lib/src/features/settings/presentation/theme/theme_mode_notifier.dart
+++ b/lib/src/features/settings/presentation/theme/theme_mode_notifier.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'theme_mode_notifier.g.dart';
+
+@Riverpod(keepAlive: true)
+class AppThemeMode extends _$AppThemeMode {
+  @override
+  Future<ThemeMode> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    final theme = prefs.getString('theme') ?? 'light';
+
+    return theme == 'light' ? ThemeMode.light : ThemeMode.dark;
+  }
+
+  // テーマの切り替え
+  void toggleTheme() async {
+    // テーマを保存
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setString('theme', state == const AsyncData(ThemeMode.light) ? 'dark' : 'light');
+
+    state = AsyncData(state == const AsyncData(ThemeMode.light) ? ThemeMode.dark : ThemeMode.light);
+  }
+}

--- a/lib/src/features/settings/presentation/theme/use_device_theme_mode_notifier.dart
+++ b/lib/src/features/settings/presentation/theme/use_device_theme_mode_notifier.dart
@@ -1,0 +1,23 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'use_device_theme_mode_notifier.g.dart';
+
+@riverpod
+class UseDeviceTheme extends _$UseDeviceTheme {
+  @override
+  Future<bool> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    final bool useDeviceTheme = prefs.getBool('useDeviceTheme') ?? false;
+
+    return useDeviceTheme;
+  }
+
+  // モバイルのテーマを利用するかどうかの切り替え
+  void toggleUseDeviceTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setBool('useDeviceTheme', state == const AsyncData(true) ? false : true);
+
+    state = AsyncData(state == const AsyncData(true) ? false : true);
+  }
+}


### PR DESCRIPTION
This pull request adds constants for size and implements the UI and functionality for theme switching in the settings page. The constants for size provide predefined gap widths and heights for consistent spacing throughout the app. The theme switching feature allows users to toggle between light and dark themes, with the selected theme being persisted using shared preferences. The UI is implemented using the Riverpod state management library.